### PR TITLE
Remove availability checks for macOS 10.10

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -780,11 +780,8 @@ static void MySleepCallBack(void * refCon, io_service_t service, natural_t messa
     }
     NSTabViewItem *primaryTab = [[NSTabViewItem alloc] initWithIdentifier:@"Articles"];
     [primaryTab setLabel:NSLocalizedString(@"Articles", nil)];
-	if (@available(macOS 10.10, *)) {
-		[primaryTab setViewController:self.articleController];
-	} else {
-		[primaryTab setView:self.articleController.mainArticleView];
-	}
+    [primaryTab setViewController:self.articleController];
+
 	[self.browser setPrimaryTab:primaryTab];
 	self.foldersTree.mainView.nextKeyView = ((NSView<BaseView> *)self.browser.primaryTab.view).mainView;
     if (self.selectedArticle == nil)

--- a/Vienna/Sources/Main window/ArticleCellView.m
+++ b/Vienna/Sources/Main window/ArticleCellView.m
@@ -32,12 +32,7 @@
 	if((self = [super initWithFrame:frameRect]))
 	{
 		controller = APPCONTROLLER;
-
-		if (@available(macOS 10.10, *)) {
-			[self initializeWebKitArticleView];
-		} else {
-			[self initializeWebViewArticleView:frameRect];
-		}
+        [self initializeWebKitArticleView];
 
 		[articleView setOpenLinksInNewBrowser:YES];
 
@@ -47,7 +42,7 @@
 	return self;
 }
 
--(void)initializeWebKitArticleView API_AVAILABLE(macosx(10.10)) {
+-(void)initializeWebKitArticleView {
 	articleView = [[WebKitArticleView alloc] init];
 }
 
@@ -72,7 +67,7 @@
 	[[NSNotificationCenter defaultCenter] removeObserver:controller.browser.primaryTab.view name:WebViewProgressFinishedNotification object:articleView];
 }
 
--(void)tearDownWebViewArticleView API_AVAILABLE(macosx(10.10)) {
+-(void)tearDownWebViewArticleView {
 	ArticleView *webViewArticleView = (ArticleView *)articleView;
 	[webViewArticleView setUIDelegate:nil];
 	[webViewArticleView setFrameLoadDelegate:nil];

--- a/Vienna/Sources/Main window/BrowserTab.swift
+++ b/Vienna/Sources/Main window/BrowserTab.swift
@@ -21,7 +21,6 @@ import Cocoa
 
 // MARK: State
 
-@available(OSX 10.10, *)
 class BrowserTab: NSViewController {
 
     // MARK: Properties
@@ -172,7 +171,6 @@ class BrowserTab: NSViewController {
 
 // MARK: Tab functionality
 
-@available(OSX 10.10, *)
 extension BrowserTab: Tab {
 
     var tabUrl: URL? {
@@ -276,7 +274,6 @@ extension BrowserTab: Tab {
 
 // MARK: Webview navigation
 
-@available(OSX 10.10, *)
 extension BrowserTab: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation?) {

--- a/Vienna/Sources/Main window/BrowserTabGui.swift
+++ b/Vienna/Sources/Main window/BrowserTabGui.swift
@@ -117,7 +117,6 @@ extension BrowserTab {
 
 // MARK: Address Bar Delegate
 
-@available(OSX 10.10, *)
 extension BrowserTab: NSTextFieldDelegate {
     //TODO: things like address suggestion etc
     //TODO: restore url string when user presses escape in textfield, make webview first responder

--- a/Vienna/Sources/Main window/CustomWKWebView.swift
+++ b/Vienna/Sources/Main window/CustomWKWebView.swift
@@ -7,7 +7,6 @@
 
 import Cocoa
 
-@available(OSX 10.10, *)
 public class CustomWKWebView: WKWebView {
 
     static let clickListenerName = "clickListener"

--- a/Vienna/Sources/Main window/MainWindowController.swift
+++ b/Vienna/Sources/Main window/MainWindowController.swift
@@ -33,12 +33,8 @@ final class MainWindowController: NSWindowController {
     @IBOutlet weak var placeholderDetailView: NSView!
 
 	@objc private(set) lazy var browser: (Browser & NSViewController) = {
-		if #available(macOS 10.10, *) {
-            var controller = TabbedBrowserViewController()
-			return controller
-		} else {
-			return WebViewBrowser()
-		}
+        var controller = TabbedBrowserViewController()
+        return controller
 	}()
 
     // MARK: Initialization

--- a/Vienna/Sources/Main window/TabbedBrowserViewController.swift
+++ b/Vienna/Sources/Main window/TabbedBrowserViewController.swift
@@ -20,7 +20,6 @@
 import Cocoa
 import MMTabBarView
 
-@available(OSX 10.10, *)
 class TabbedBrowserViewController: NSViewController, RSSSource {
 
     @IBOutlet private(set) weak var tabBar: MMTabBarView? {
@@ -245,7 +244,6 @@ extension TabbedBrowserViewController: Browser {
     }
 }
 
-@available(OSX 10.10, *)
 extension TabbedBrowserViewController: MMTabBarViewDelegate {
     func tabView(_ aTabView: NSTabView, shouldClose tabViewItem: NSTabViewItem) -> Bool {
         tabViewItem != primaryTab
@@ -301,7 +299,7 @@ extension TabbedBrowserViewController: MMTabBarViewDelegate {
     }
 }
 
-@available(OSX 10.10, *)
+
 extension TabbedBrowserViewController: CustomWKUIDelegate {
     //TODO: implement functionality for alerts and maybe peek actions
 

--- a/Vienna/Sources/Main window/TitleChangingTabViewItem.swift
+++ b/Vienna/Sources/Main window/TitleChangingTabViewItem.swift
@@ -21,7 +21,6 @@
 
 import Cocoa
 
-@available(OSX 10.10, *)
 class TitleChangingTabViewItem: NSTabViewItem {
 
     var titleObservation: NSKeyValueObservation?

--- a/Vienna/Sources/Main window/WebKitArticleView.swift
+++ b/Vienna/Sources/Main window/WebKitArticleView.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-@available(OSX 10.10, *)
 @objc
 class WebKitArticleView: CustomWKWebView, ArticleContentView {
 


### PR DESCRIPTION
Our minimum deployment target is now 10.11 so we don't need to check
for 10.10